### PR TITLE
Functional enhancement 1 from exception 2 branch

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -31,3 +31,10 @@
 #error_explanation ul li {
   list-style: initial;
 }
+
+/* Back link */
+.back {
+  display: block;
+  margin-top: 1rem;
+  color: white;
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -148,7 +148,14 @@ body {
   background-color: white;
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.5);
   transition: 0.5s right;
-  overflow-y: auto;
+  overflow-y: scroll; //スクロールバー常時表示で適用ボタンのガタツキを防止
+}
+
+@media (max-width: 768px) {
+  .settings-list {
+    width: 90vw;
+    right: -90vw;
+  }
 }
 
 .settings-list .close {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -207,3 +207,18 @@ body {
   display: block;
   margin: 0 auto;
 }
+
+/* サブメニュー画面（スイッチ部） */
+.form-switch .form-check-input:checked {
+  background-color: green;
+  border-color: green;
+}
+
+.form-switch .form-check-input {
+  border-color: gray;
+  color: gray;
+}
+
+.form-switch .form-check-input:focus {
+  box-shadow: 0 0 0 0.25rem lightgray;
+}

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -5,6 +5,9 @@ body {
   min-height: 100vh;
   width: 100vw;
   overflow: hidden;
+  font-family: "Yomogi", cursive;
+  font-weight: 600;
+  font-style: normal;
 }
 
 .main {

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -222,3 +222,12 @@ body {
 .form-switch .form-check-input:focus {
   box-shadow: 0 0 0 0.25rem lightgray;
 }
+
+/* サブメニュー画面（アコーディオンヘッダー部） */
+.accordion-button:not(.collapsed) {
+  background-color: transparent;
+}
+
+.accordion-item:focus-within .accordion-button {
+  box-shadow: none;
+}

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -19,19 +19,25 @@ const timerTitle = getElement('timerTitle');
 const circle = getElement('circle');
 const modeEl = getElement('mode');
 
-// check later この変数名見直せ
-const checkbox = document.getElementById('flexSwitchCheckChecked');
-const messageCheckbox = document.getElementById('messageCheckbox');
+const automaticWorkStart = document.getElementById('setting_automatic_work_start');
+const automaticBreakStart = document.getElementById('setting_automatic_break_start');
+const soundNotification = document.getElementById('setting_sound_notification');
+const displayMessage = document.getElementById('setting_display_message');
 
 const playButton = document.getElementById("play-button");
 playButton.addEventListener("click", function () {
-  if (messageCheckbox.checked) {
-    createText()
+  const circle = document.getElementById("circle");
+  const angle = circle.style.getPropertyValue("--angle");
+  const color = circle.style.getPropertyValue("--color");
+
+  if (angle === "360deg" && color === "red") {
+    createText();
   }
+
 }, false);
 
 updateCountdown(time);
-timerTitle.innerText = "Simple Pomodoro Timer"; //追加
+timerTitle.innerText = "Simple Pomodoro Timer";
 
 // 関数
 function countdown(pTime) {
@@ -72,8 +78,17 @@ function swapMode() {
 function updateCountdown(pTime) {
   if (pTime <= 0) {
     circle.style.setProperty('--angle', '360deg');
-    if (checkbox.checked) {
+    if (soundNotification.checked) {
       document.getElementById('btn_audio').play();
+    }
+
+    // 休憩時間になったら自動で開始する:ON
+    if (!automaticWorkStart.checked && currentMode == "Work") {
+      // pause();
+    }
+    // 作業時間になったら自動で開始する:ON
+    if (!automaticBreakStart.checked && currentMode != "Work") {
+      // pause();
     }
   } else {
     let color;
@@ -82,9 +97,11 @@ function updateCountdown(pTime) {
     if (currentMode == "Work") {
       color = "red";
       angle = (pTime / pomodoro * 360) + 'deg';
+
     } else if (currentMode == "Rest") {
       color = "blue";
       angle = (pTime / shortBreak * 360) + 'deg';
+
     } else {
       color = "green";
       angle = (pTime / longBreak * 360) + 'deg';
@@ -129,6 +146,7 @@ function stop() {
 function setImage() {
   let bgImage;
   let selectedOption = document.querySelector('input[name="setting[theme]"]:checked').id;
+  console.log("Selected option:", selectedOption);
 
   switch (selectedOption) {
     case 'option1': bgImage = 'option1.jpg'; break;
@@ -139,6 +157,7 @@ function setImage() {
 
   localStorage.setItem('bgImage', bgImage);
   document.body.style.backgroundImage = `url(${bgImage})`;
+  console.log("pic:", document.body.style.backgroundImage);
 }
 
 // DOM要素の値を取得
@@ -185,6 +204,7 @@ function closeSettings() {
 function openSettings() {
   let settingsList = document.querySelectorAll('.settings-list')[0];
   settingsList.style.right = "0";
+  console.log("Open: window.innerWidth: ", window.innerWidth);
 }
 
 // 応援メッセージを動的に作成する
@@ -205,6 +225,9 @@ async function createText() {
     transform: translateY(-50%);
     z-index: 9999;
     color: white;
+    font-family: "Hachi Maru Pop", cursive;
+    font-weight: 400;
+    font-style: normal;
   `;
 
   divText.textContent = messages[Math.floor(Math.random() * messages.length)];
@@ -252,4 +275,6 @@ window.onload = function () {
 };
 
 //for debug
-// openSettings();
+openSettings();
+
+

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -187,8 +187,8 @@ function applySettings() {
   numberWorkIntervals = longBreakInterval;
   time = pomodoro;
 
-  // 背景画像セット
   setImage();
+  closeSettings();
 
   clearInterval(interval);
   updateCountdown(time);

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -197,6 +197,11 @@ function applySettings() {
 function closeSettings() {
   let settingsList = document.querySelectorAll('.settings-list')[0];
   settingsList.style.right = "-33vw";
+  let width = window.innerWidth; // 現在のウィンドウの幅を取得
+  if (width > 768) {
+    width = width / 3
+  }
+  settingsList.style.right = `-${width}px`; // 現在のウィンドウの幅分だけ右に移動
 }
 
 function openSettings() {
@@ -272,6 +277,6 @@ window.onload = function () {
 };
 
 //for debug
-openSettings();
+// openSettings();
 
 

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -13,20 +13,24 @@ function getElement(id) {
   return document.getElementById(id);
 }
 
+function getElementValue(id) {
+  return document.getElementById(id).value;
+}
+
 // DOM 
 const timer = getElement('timer');
 const timerTitle = getElement('timerTitle');
 const circle = getElement('circle');
 const modeEl = getElement('mode');
 
-const automaticWorkStart = document.getElementById('setting_automatic_work_start');
-const automaticBreakStart = document.getElementById('setting_automatic_break_start');
-const soundNotification = document.getElementById('setting_sound_notification');
-const displayMessage = document.getElementById('setting_display_message');
+const automaticWorkStart = getElement('setting_automatic_work_start');
+const automaticBreakStart = getElement('setting_automatic_break_start');
+const soundNotification = getElement('setting_sound_notification');
+const displayMessage = getElement('setting_display_message');
 
-const playButton = document.getElementById("play-button");
+const playButton = getElement("play-button");
 playButton.addEventListener("click", function () {
-  const circle = document.getElementById("circle");
+  const circle = getElement("circle");
   const angle = circle.style.getPropertyValue("--angle");
   const color = circle.style.getPropertyValue("--color");
 
@@ -79,7 +83,7 @@ function updateCountdown(pTime) {
   if (pTime <= 0) {
     circle.style.setProperty('--angle', '360deg');
     if (soundNotification.checked) {
-      document.getElementById('btn_audio').play();
+      getElement('btn_audio').play();
     }
 
     // 休憩時間になったら自動で開始する:ON
@@ -156,11 +160,6 @@ function setImage() {
 
   localStorage.setItem('bgImage', bgImage);
   document.body.style.backgroundImage = `url(${bgImage})`;
-}
-
-// DOM要素の値を取得
-function getElementValue(id) {
-  return document.getElementById(id).value;
 }
 
 // 設定反映

--- a/app/javascript/index.js
+++ b/app/javascript/index.js
@@ -1,7 +1,7 @@
 // 変数
 let pomodoro = 25 * 60 * 1000;  //1ポモドーロの長さ(デフォルト)
 let shortBreak = 5 * 60 * 1000; //短時間休憩(デフォルト)
-let longBreak = 15 * 60 * 1000;
+let longBreak = 15 * 60 * 1000; //長時間休憩(デフォルト)
 let longBreakInterval = 4;
 let currentMode = "Work";
 
@@ -84,11 +84,11 @@ function updateCountdown(pTime) {
 
     // 休憩時間になったら自動で開始する:ON
     if (!automaticWorkStart.checked && currentMode == "Work") {
-      // pause();
+      pause();
     }
     // 作業時間になったら自動で開始する:ON
     if (!automaticBreakStart.checked && currentMode != "Work") {
-      // pause();
+      pause();
     }
   } else {
     let color;
@@ -146,7 +146,6 @@ function stop() {
 function setImage() {
   let bgImage;
   let selectedOption = document.querySelector('input[name="setting[theme]"]:checked').id;
-  console.log("Selected option:", selectedOption);
 
   switch (selectedOption) {
     case 'option1': bgImage = 'option1.jpg'; break;
@@ -157,7 +156,6 @@ function setImage() {
 
   localStorage.setItem('bgImage', bgImage);
   document.body.style.backgroundImage = `url(${bgImage})`;
-  console.log("pic:", document.body.style.backgroundImage);
 }
 
 // DOM要素の値を取得
@@ -204,7 +202,6 @@ function closeSettings() {
 function openSettings() {
   let settingsList = document.querySelectorAll('.settings-list')[0];
   settingsList.style.right = "0";
-  console.log("Open: window.innerWidth: ", window.innerWidth);
 }
 
 // 応援メッセージを動的に作成する

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,6 +3,8 @@
     <h2>マイページ編集</h2>
 
     <%= form_with model: resource, url: registration_path(resource_name), local: true, method: :put, class: 'form' do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
       <div class="form-group">
         <%= f.label :email, 'メールアドレス（必須）:' %>
         <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-input' %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -27,5 +27,6 @@
         <%= f.submit '更新する', class: 'btn btn-secondary' %>
       </div>
     <% end %>
+    <%= link_to '戻る', 'javascript:history.back()', class: 'back' %>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,6 +3,15 @@
     <h1>アカウント登録</h1>
 
     <%= form_with model: @user, as: resource_name, url: registration_path(resource_name), local: true, class: 'form' do |f| %>
+      <% if alert.present? %>
+        <div id="error_explanation">
+          <h2>エラー:</h2>
+          <ul>
+            <li><%= alert %></li>
+          </ul>
+        </div>
+      <% end %>
+
       <%= render "devise/shared/error_messages", resource: @user %>
       <div class="form-group">
         <%= f.label :email, 'メールアドレス（必須）:' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,5 +23,6 @@
         <%= f.submit '登録する', class: 'btn btn-secondary' %>
       </div>
     <% end %>
+    <%= link_to '戻る', 'javascript:history.back()', class: 'back' %>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,7 +6,7 @@
 
       <% if alert.present? %>
         <div id="error_explanation">
-          <h2>エラー:</h2>          
+          <h2>エラー:</h2>
           <ul>
             <li><%= alert %></li>
           </ul>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -34,6 +34,7 @@
         <%= f.submit 'ログインする', class: 'btn btn-secondary' %>
       </div>
     <% end %>
+    <%= link_to '戻る', 'javascript:history.back()', class: 'back' %>
   </div>
 </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,12 @@
     <script src="https://kit.fontawesome.com/48e9ba994a.js" crossorigin="anonymous"></script>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%# stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_importmap_tags %>
+
+    <!-- google fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Darumadrop+One&family=DotGothic16&family=Hachi+Maru+Pop&family=RocknRoll+One&family=Sora:wght@100..800&family=Yomogi&display=swap" rel="stylesheet">
   </head>
 
   <body class="bg-image">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -18,7 +18,7 @@
       <i class="fa-solid fa-2x fa-xmark close"></i>
       <%= form_with model: @setting, local: true, class: 'form', method: :patch do |f| %>
         <div class="form-group">
-          <%= f.label :work_minute, '１作業（１ポモドーロ）の長さ：' %>
+          <%= f.label :work_minute, '１作業の長さ：' %>
           <%= f.number_field :work_minute, class: 'form-input', min: 0, max: 99, step: 1 %>
           <%= f.label :work_minute, '分' %>
           <%= f.number_field :work_second, class: 'form-input', min: 0, max: 99, step: 1 %>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -43,7 +43,7 @@
             <%= f.label :long_break_minute, '長い休憩時間：' %>
             <%= f.number_field :long_break_minute, class: 'form-input', min: 0, max: 99, step: 1 %>
             <%= f.label :long_break_minute, '分' %>
-            <%= f.number_field :long_break_minute, class: 'form-input', min: 0, max: 99, step: 1 %>
+            <%= f.number_field :long_break_second, class: 'form-input', min: 0, max: 99, step: 1 %>
             <%= f.label :long_break_second, '秒' %>
           </div>
           <%= f.label :work_interval, '長い休憩まで作業(ポモドーロ)回数' %>
@@ -59,7 +59,7 @@
 
         <div class="form-group form-check form-switch form-check-reverse">
           <%= f.label :sound_notification, '通知音', class: "form-check-label" %>
-          <%= f.check_box :sound_notification, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" } %>
+          <%= f.check_box :sound_notification, { class: "form-check-input", role: "switch"} %>
         </div>
 
         <div class="accordion accordion-flush" id="accordionFlushExample">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -46,7 +46,7 @@
             <%= f.number_field :long_break_second, class: 'form-input', min: 0, max: 99, step: 1 %>
             <%= f.label :long_break_second, '秒' %>
           </div>
-          <%= f.label :work_interval, '長い休憩まで作業(ポモドーロ)回数' %>
+          <%= f.label :work_interval, '長い休憩まで作業(ポモドーロ)回数：' %>
           <%= f.number_field :work_interval, class: 'form-input', min: 0, max: 99, step: 1 %>
         </div>
 


### PR DESCRIPTION
## 動作確認
参考画像
![image](https://github.com/sugachan-hc/pomodoro6/assets/10960663/06e95f88-ff82-4f7b-905e-b09c6608da21)

![image](https://github.com/sugachan-hc/pomodoro6/assets/10960663/1e7e5acb-5e69-4733-840c-87c3ba9a5897)     
![image](https://github.com/sugachan-hc/pomodoro6/assets/10960663/1ded854b-9f2b-44cb-9f82-74ca0da2d7a0)                        .

## やったこと
【機能改善】
・サブメニュー表示時、適用ボタンを押したときサブメニューが自動で閉じるようにしました。(画像なし)
・フォント設定をカスタマイズしました。（フォントチョイスはお好みで）(画像あり)
・レスポンシブに対応。スマホでもサブメニューが広く表示されるよう修正しました。(画像あり)
・Bootstrap(BS)のスイッチの色をカスタマイズしました。(BSっぽさをなくしたかった)(画像あり)
・BSのアコーディオンのフォーカス時のデフォルト表示の色をカスタマイズしました。(BSっぽさをなくしたかった)(画像あり)
・ログイン画面等Devise画面でトップに戻るリンクを追加しました。(画像あり)
・JSファイルを一部りリファクタリングしました。
・スクロールバーの有無でボタン表示等が少し左右にずれて表示されてしまうガタツキをなくしました。(画像なし)

【不具合修正】
・自動開始のスイッチボタンが機能していませんでした。修正しました。
・パスワード変更画面のバリデーションエラーが表示されていませんでした。これを修正しました。

## 実装のリンク
[<!-- ガントチャートのタスク対象のセルのリンクを貼る -->](https://docs.google.com/spreadsheets/d/1dfAJM3Lu_StAOCAnFGv5BXl7is24WnHrLRD6Hbxfwf8/edit#gid=278761686&range=B24:C24)

## 備考

